### PR TITLE
Change s-bit clusterization clock to 160MHz

### DIFF
--- a/src/optohybrid_top.vhd
+++ b/src/optohybrid_top.vhd
@@ -523,7 +523,7 @@ begin
     -- This module handles the SBits
     sbits_inst : entity work.sbits
     port map(        
-        ref_clk_i               => ref_clk,
+        ref_clk_i               => gtx_clk,
         reset_i                 => reset,        
         vfat2_sbits_i           => vfat2_sbits_b,  
         vfat2_sbit_mask_i       => vfat2_sbit_mask,        


### PR DESCRIPTION
Need to use 160 MHz clock for packing S-bits, otherwise lose 3/4 of trigger data
